### PR TITLE
CMake: Add include directory to target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 set (NAME cpp-optparse)
 set (SRCS OptionParser.cpp)
-add_library(${NAME} STATIC ${SRCS} )
+add_library(${NAME} STATIC ${SRCS})
 target_link_libraries(${NAME} FEXCore_Base)
+target_include_directories(${NAME} INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")


### PR DESCRIPTION
Previously FEX had to manually add these include directories for each target that links against cpp-optparse. Propagating them automatically is easier.