### PR TITLE
On failure, exit by error code instead of throwing an unspecific exception

### DIFF
--- a/OptionParser.cpp
+++ b/OptionParser.cpp
@@ -467,7 +467,7 @@ void OptionParser::print_version() const {
 }
 
 void OptionParser::exit() const {
-  throw 2;
+  std::exit(EXIT_FAILURE);
 }
 void OptionParser::error(const fextl::string& msg) const {
   print_usage(std::cerr);


### PR DESCRIPTION
Without explicit handling, exceptions are turned into this unnecessarily verbose log at runtime:

```
~/coding/FEX/build$ FEXpidof --test
Usage: FEXpidof [options]

FEXpidof: error: no such option: --test
terminate called after throwing an instance of 'int'
Aborted (core dumped)
```

With this change, the last two lines disappear.